### PR TITLE
Load all external resources over http

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
 <link href="css/bootstrap.min.css" rel="stylesheet">
 <link href="css/bootstrap-responsive.min.css" rel="stylesheet">
 <link href="https://fonts.googleapis.com/css?family=Open+Sans:400italic,600italic,400,600" rel="stylesheet">
-<link href="//netdna.bootstrapcdn.com/font-awesome/3.2.1/css/font-awesome.min.css" rel="stylesheet">
+<link href="https://netdna.bootstrapcdn.com/font-awesome/3.2.1/css/font-awesome.min.css" rel="stylesheet">
 <link href="css/style.css" rel="stylesheet">
 <link href="css/pages/dashboard.css" rel="stylesheet">
 <link href="css/odometer.css" rel="stylesheet">
@@ -300,7 +300,7 @@
 <!-- Placed at the end of the document so the pages load faster --> 
 <script src="js/jquery.js"></script> 
 <script src="js/bootstrap.js"></script>
-<script src="//cdnjs.cloudflare.com/ajax/libs/datatables/1.9.4/jquery.dataTables.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/datatables/1.9.4/jquery.dataTables.min.js"></script>
 <script src="js/odometer.js"></script>
 <script src="js/magic_happens_here.js"></script>
 


### PR DESCRIPTION
Fonts and stuff won't load on Chrome (possibly others) if linux-dash is installed on an `https` webserver, because they were being loaded over http. This corrects that by forcing them all to https. I also added an `https` to the github link.
