### PR TITLE
username column lenght increase to 20

### DIFF
--- a/sh/online.php
+++ b/sh/online.php
@@ -1,5 +1,7 @@
 <?php 
 
+    // change username column length for w command
+    exec('export PROCPS_USERLEN=20');
     exec('w -h | awk \'{print " "$1","$3","$4","$5}\'',$users);
     $result = array();
     foreach ($users as $user)


### PR DESCRIPTION
If username is longer then 8 character, 'online users' part's usernames gets shorten to the first 8 character of username. So this makes it longer to 20.
