### PR TITLE
Minor ps fixes

### DIFF
--- a/sh/ps.php
+++ b/sh/ps.php
@@ -1,7 +1,7 @@
 <?php
     // Execute top command on server to get results of ps aux
     // each row (including header) is in csv format
-    exec('ps aux|awk '."'{print ".'$1","$2","$3","$4","$5","$6","$7","$8","$9","$10","$11'."}'", $result);
+    exec('ps aux|awk '."'NR>1{print ".'$1","$2","$3","$4","$5","$6","$7","$8","$9","$10","$11'."}'", $result);
     
     header('Content-Type: application/json; charset=UTF-8');
 


### PR DESCRIPTION
`-aux` is not valid in any of the three syntaxes but is typically treated as BSD's `aux`. If and when this changes the semantics between the BSD and GNU versions will not be the same.
`ps.php` outputs `ps`' column headers but these are already in the table. They will appear as a row of data.
