### PR TITLE
added iostatCpu for evaluation by project

### DIFF
--- a/sh/iostatCpu.php
+++ b/sh/iostatCpu.php
@@ -1,0 +1,7 @@
+<?php
+    // Execute top command on server to get results of ps aux
+    // each row (including header) is in csv format
+    exec('iostat|awk \'{print $1","$2","$3","$4","$5","$6","$7}\'', $result);
+    
+    header('Content-Type: application/json; charset=UTF-8');
+    echo json_encode( explode(',',$result[3]) );


### PR DESCRIPTION
I find the output of 'iostat' to be incredibly helpful for quick glance server status - however it is not installed by default on most systems.

This fork adds cpu idle, system, and user loads to the processes dashboard. For me personally this is helpful info, but not sure how your project feels about the inclusion of non-standard tools.

Issuing a pull request just to open discussion - can revise this fork with a method to not impact index.html if iostat not installed on the system, better page style for including what's here,  and to add the other helpful info from iostat (disk iops)  if project maintainer is interested? 
