### PR TITLE
Fixes #67

### DIFF
--- a/sh/df.php
+++ b/sh/df.php
@@ -1,6 +1,6 @@
 <?php 
 
-    exec('df -h|awk \'{print $1","$2","$3","$4","$5","$6}\'',$result);
+    exec('/bin/df -h|awk \'{print $1","$2","$3","$4","$5","$6}\'',$result);
     header('Content-Type: application/json; charset=UTF-8');
 
     echo "[";

--- a/sh/issue.php
+++ b/sh/issue.php
@@ -1,3 +1,3 @@
 <?php 
 header('Content-Type: application/json; charset=UTF-8');
-echo json_encode(shell_exec('lsb_release -ds;uname -r')) ;
+echo json_encode(shell_exec('/usr/bin/lsb_release -ds;/bin/uname -r')) ;

--- a/sh/mem.php
+++ b/sh/mem.php
@@ -3,7 +3,7 @@
     //exec('cat /proc/meminfo|awk \'{print $1","$2}\'',$result);
     //exec('free -m|awk \'{print $1","$2","$3","$4}\'',$result);
 
-    exec('free -tmo|awk \'{print $1","$2","$3-$6-$7","$4+$6+$7}\'',$result);
+    exec('/usr/bin/free -tmo | /usr/bin/awk \'{print $1","$2","$3-$6-$7","$4+$6+$7}\'',$result);
     header('Content-Type: application/json; charset=UTF-8');
 	echo json_encode( explode(',',$result[1]) );
 	

--- a/sh/numberofcores.php
+++ b/sh/numberofcores.php
@@ -1,6 +1,6 @@
 <?php 
 
-    exec('grep -c ^processor /proc/cpuinfo',$result);
+    exec('/bin/grep -c ^processor /proc/cpuinfo',$result);
     header('Content-Type: application/json; charset=UTF-8');
     echo json_encode( $result[0] );
     

--- a/sh/online.php
+++ b/sh/online.php
@@ -2,7 +2,7 @@
 
     // change username column length for w command
     putenv("PROCPS_USERLEN=20");
-    exec('w -h | awk \'{print $1","$3","$4","$5}\'',$users);
+    exec('/usr/bin/w -h | /usr/bin/awk \'{print $1","$3","$4","$5}\'',$users);
     $result = array();
     foreach ($users as $user)
     {

--- a/sh/test.php
+++ b/sh/test.php
@@ -1,6 +1,6 @@
 <pre><?php 
 
-$milli = shell_exec('awk \'{print $1*1000}\' /proc/uptime');
+$milli = shell_exec('/usr/bin/awk \'{print $1*1000}\' /proc/uptime');
 
 header('Content-Type: application/json; charset=UTF-8');
 

--- a/sh/top.php
+++ b/sh/top.php
@@ -1,7 +1,7 @@
 <?php
     // Execute top command on server
     // Store the result in $result (1 line = 1 array element)
-    exec('/usr/bin/top -b -n1|awk \'{print $2}\'', $result);
+    exec('/usr/bin/top -b -n1 | /usr/bin/awk \'{print $2}\'', $result);
     
     /*
     // Extract the headers from resultset

--- a/sh/uptime.php
+++ b/sh/uptime.php
@@ -1,4 +1,4 @@
 <?php
 
 header('Content-Type: application/json; charset=UTF-8'); 
-echo json_encode((int) (shell_exec('cat /proc/uptime')/(60*60)));
+echo json_encode((int) (shell_exec('/bin/cat /proc/uptime')/(60*60)));

--- a/sh/users.php
+++ b/sh/users.php
@@ -1,6 +1,6 @@
 <?php 
 
-    exec('awk -F: \'{ if ($3<=499) print "system,"$1","$6; else print "user,"$1","$6; }\' < /etc/passwd',$result);
+    exec('/usr/bin/awk -F: \'{ if ($3<=499) print "system,"$1","$6; else print "user,"$1","$6; }\' < /etc/passwd',$result);
     
     header('Content-Type: application/json; charset=UTF-8');
     echo "[";

--- a/sh/whereis.php
+++ b/sh/whereis.php
@@ -1,7 +1,7 @@
 <?php 
 
-    exec('whereis php node mysql vim python ruby java apache2 nginx openssl vsftpd make'.
-          '|awk \'{ split($1, a, ":");if (length($2)==0) print a[1]",Not Installed"; else print a[1]","$2;}\'',$result);
+    exec('/usr/bin/whereis php node mysql vim python ruby java apache2 nginx openssl vsftpd make'.
+          '| /usr/bin/awk \'{ split($1, a, ":");if (length($2)==0) print a[1]",Not Installed"; else print a[1]","$2;}\'',$result);
     
     header('Content-Type: application/json; charset=UTF-8');
 


### PR DESCRIPTION
Fixes absolute paths to Linux binaries in php shell commands. Not having absolute paths can cause issues when executing in an environment without the correct variables setup ($PATH for example).
