### PR TITLE
CSS media query changes for refresh button issues on a couple screen sizes.

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1268,7 +1268,11 @@ width: 11px;}
 	.widget-header {
 		height: 100%;
 	}
-	
+
+	.widget-header h3 {
+		margin-right: 1em;
+	}
+
 	.js-refresh-info {
 		margin-left: 25px;
 	}


### PR DESCRIPTION
At 979 and 1199 widths, the refresh button on some widget boxes would float into the content area for the widget.  Attached are two images for the Internet Speed widget showing this. Though it happened on other widgets as well (if the h3 title was long enough to push button down).
![979](https://f.cloud.github.com/assets/3073072/2080780/83a28b06-8dda-11e3-8ac7-9efaf1b96c76.png)
![1199](https://f.cloud.github.com/assets/3073072/2080781/83b3f396-8dda-11e3-8542-020867ee2ee6.png)
