### PR TITLE
`whereis` isn't portable - switch to which

### DIFF
--- a/sh/whereis.php
+++ b/sh/whereis.php
@@ -1,18 +1,15 @@
 <?php 
 
-    exec('/usr/bin/whereis php node mysql vim python ruby java apache2 nginx openssl vsftpd make'.
-          '| /usr/bin/awk \'{ split($1, a, ":");if (length($2)==0) print a[1]",Not Installed"; else print a[1]","$2;}\'',$result);
-    
+    $binaries = explode(" ", "php node mysql vim python ruby java apache2 nginx openssl vsftpd make");
+
     header('Content-Type: application/json; charset=UTF-8');
 
-    echo "[";
-    $x = 0;
-    $max = count($result)-1;
-    foreach ($result as $a)
-    {    
-        echo json_encode( explode(',',$result[$x]) );
-        echo ($x==$max)?'':',';
-        unset($result[$x],$a);
-        $x++;
+    $data = array();
+    foreach($binaries as $b)
+    { 
+        $which = array();
+        exec('/usr/bin/which ' . escapeshellarg($b), $which, $return_var);
+        $data[] = array($b, $return_var ? "Not Installed" : $which[0]);
     }
-    echo ']';
+    
+    echo json_encode($data);


### PR DESCRIPTION
`whereis` provides different results on different OS's.  Changed to use which

See FreeBSD:

```
jdonat > JesseDonat-MBP ~ » /usr/bin/whereis php node mysql vim python ruby java apache2 nginx openssl vsftpd make                                                 1↵ 15:58:57
/usr/bin/php
/usr/bin/vim
/usr/bin/python
/usr/bin/ruby
/usr/bin/java
/usr/bin/openssl
/usr/bin/make
```

vs CentOS

```
php: /usr/bin/php /etc/php.ini /etc/php.d /usr/lib64/php /usr/share/php /usr/share/man/man1/php.1.gz
node:
mysql: /usr/bin/mysql /usr/lib64/mysql /usr/include/mysql /usr/share/mysql /usr/share/man/man1/mysql.1.gz
vim: /usr/bin/vim /usr/share/vim /usr/share/man/man1/vim.1.gz
python: /usr/bin/python2.6 /usr/bin/python2.6-config /usr/bin/python /usr/lib/python2.6 /usr/lib64/python2.6 /usr/local/bin/python2.7-config /usr/local/bin/python2.7 /usr/local/bin/python /usr/local/lib/python2.7 /usr/include/python2.6 /usr/share/man/man1/python.1.gz
ruby: /usr/lib/ruby /usr/lib64/ruby /usr/local/bin/ruby /usr/local/lib/ruby
java: /usr/bin/java /etc/java /usr/lib/java /usr/share/java /usr/share/man/man1/java.1.gz
apache2:
nginx:
openssl: /usr/bin/openssl /usr/lib64/openssl /usr/include/openssl /usr/share/man/man1/openssl.1ssl.gz
vsftpd:
make: /usr/bin/make /usr/share/man/man1/make.1.gz /usr/share/man/man1p/make.1p.gz
```
