### PR TITLE
netstat refresh removes proccesses search text

### DIFF
--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -130,7 +130,6 @@ dashboard.getPs = function() {
 dashboard.getNetStat = function() {
     $.get("sh/netstat.php", function(data) {
         destroy_dataTable("netstat_dashboard");
-        $("#filter-ps").val("").off("keyup");
 
         $("#netstat_dashboard").dataTable({
             aaData: data,


### PR DESCRIPTION
Seems like this line was copied by mistake from the proccesses widget code.
What happens is that when you refresh the netstat widget it empties the proccesses search text fields.
