### PR TITLE
Can't select text field in sortable widget

### DIFF
--- a/js/base.js
+++ b/js/base.js
@@ -71,7 +71,7 @@ function pulseElement(element, times, interval) {
 $( ".row" ).sortable({
       connectWith: ".row",
       handle: ".widget-header",
-      cancel: "",
+      cancel: "#filter-ps",
       cursor: "move",
       opacity: 0.7,
       scrollSensitivity:10,


### PR DESCRIPTION
When trying to select the search text field in the processes widget it interferes with the 'sortable' functionality and causing problems.
Adding this attribute fixes the problem.
I confirmed this on chrome, firefox and ie.
