### PR TITLE
Fix Chrome smooth-scroll regression.

### DIFF
--- a/js/base.js
+++ b/js/base.js
@@ -9,7 +9,7 @@ $(document).ready(function() {
         var target = $(this.hash).parent();
         pulseElement(target, 8, 400);
 
-        $("html").animate({
+        $("html,body").animate({
             scrollTop: target.offset().top - 130
         }, 1000);
     });


### PR DESCRIPTION
Some versions of Chrome will not scroll correctly if the sizzle does
not contain both the html and the body tag.
