### PR TITLE
Added % disk used bar below each filesystem

### DIFF
--- a/css/pages/dashboard.css
+++ b/css/pages/dashboard.css
@@ -355,3 +355,90 @@ h6.bigstats {
 .dataTables_paginate a:hover{ pointer:pointer;}
 .navbar-fixed-top{  margin-left:0px;}
 .widget-search{display: inline-block; vertical-align: middle; margin: 0 6px; width: 200px;}
+
+/* Added by kevinrabinovich */
+meter {
+    /* Reset appearance */
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    appearance: none;
+	background: #ddd;
+	width: 100%;
+	height: 18px;
+	border: none;
+	-webkit-border-radius: 3px;
+	-moz-border-radius: 3px;
+	border-radius: 3px;
+}
+meter::-webkit-meter-bar {
+	background: #ddd;
+	-webkit-border-radius: 3px;
+	border-radius: 3px;
+}
+meter::-webkit-meter-optimum-value {
+	background: #444;
+	-webkit-border-radius: 3px;
+	border-radius: 3px;
+}
+meter::-moz-meter-bar {
+	background: #ddd;
+	-moz-border-radius: 3px;
+    border-radius: 3px;
+}
+meter:-moz-meter-optimum::-moz-meter-bar {
+	background: #444;
+	-moz-border-radius: 3px;
+	border-radius: 3px;
+}
+
+/*<progress> fallback styling*/
+progress {
+	/*Reset appearance*/
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    appearance: none;
+	background: #ddd;
+	color: #444; /*For IE*/
+	width: 100%;
+	height: 18px;
+	border: 0;
+	-webkit-border-radius: 3px;
+	-moz-border-radius: 3px;
+	border-radius: 3px;
+}
+progress[value] {
+	/*Reset appearance*/
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    appearance: none;
+}
+progress::-webkit-progress-bar {
+    background: #ddd;
+	-webkit-border-radius: 3px;
+    border-radius: 3px;
+}
+progress::-webkit-progress-value {
+    background-color: #444;
+	-webkit-border-radius: 3px;
+    border-radius: 3px;
+}
+progress::-moz-progress-bar {
+    background-color: #444;
+	-moz-border-radius: 3px;
+    border-radius: 3px;
+}
+/*<div> > <span> fallback styling*/
+.progress-bar {
+  background-color: #ddd;
+  border-radius: 3px;
+  width: 100%;
+  height: 18px;
+  position: relative;
+  display: block;
+}
+  
+.progress-bar > span {
+  background-color: #444;
+  border-radius: 3px;
+  display: block;
+}

--- a/js/base.js
+++ b/js/base.js
@@ -52,6 +52,40 @@ $(function() {
     }
   });
 });
-	
-	
+
+/* Added by kevinrabinovich */
+	//Adds <meter> element displaying % disk used
+	//Tests if the following has already been run, because it runs twice otherwise		
+	var progressPresent = document.getElementsByTagName("progress");
+	var meterPresent = document.getElementsByTagName("meter");
+	var progressBarClassPresent = document.getElementsByClassName("progress-bar");
+	if ((!(progressPresent.length > 0) || (!(meterPresent.length > 0)) || (!(progressBarClassPresent.length > 0))) /*If progress, meter, or .progress-bar doesn't exist*/) {
+		var table = document.getElementById('df_dashboard'); //Table
+		var rows = table.rows.length; //All rows
+		for (i = 1; i < rows; i++){
+			//For each row
+			var tcells = table.rows.item(i).cells; //All cells in this row
+			var usedTotal = 0;
+			var totalUsedLength = tcells.item(4).innerHTML.length - 1; //Length of characters in cell; subtracting 1 to account for '%'
+			for (j = totalUsedLength - 1; j >= 0; j--) { //For each place digit j in number; subtracting 1 because index is 0-based
+				if (totalUsedLength == 1) { //If there are only units, i.e. no tens
+					usedTotal += parseInt(tcells.item(4).innerHTML[j]);
+				}
+				else {
+					switch (j) {
+						case 1: //units
+							usedTotal += parseInt(tcells.item(4).innerHTML[j]);
+							break;
+						case 0: //tens
+							usedTotal += 10*parseInt(tcells.item(4).innerHTML[j]);
+							break;
+						default:
+							break;
+					}
+				}
+			}
+			tcells.item(0).innerHTML += "<meter max=100" + " value=" + usedTotal + " ><progress " + " position=" + usedTotal/100 + " value=" + usedTotal/100 + " >" + "<div class=progress-bar><span style=width:" + usedTotal + "% ></span></div></progress></meter>";
+		//End for each row
+		}
+	}
 });


### PR DESCRIPTION
Added individual `<meter>` bars below each filesystem name, with fallbacks
in case `<meter>` isn't supported (first `<progress>`, then `<div> > <span>`).
Supported in WebKit browsers (Safari/Chrome), Firefox, and IE.
