### PR TITLE
Give user ability to define hosts to ping

### DIFF
--- a/sh/ping.php
+++ b/sh/ping.php
@@ -7,7 +7,7 @@
     }
     // If file doesn't exist then use hard coded list
     else {
-        hosts = array("gnu.org", "github.com", "wikipedia.org");
+        $hosts = array("gnu.org", "github.com", "wikipedia.org");
     }
 
     $pingCount = 2;


### PR DESCRIPTION
This commit gives the ping widget the ability to read the contents of file "ping_hosts" so users can define which hosts get pinged for the ping widget, same as the where.php widget.

Not sure if 'master' is the correct branch to submit to.
