### PR TITLE
Close #135: adopt full PSR-2 compliance.

### DIFF
--- a/sh/bandwidth.php
+++ b/sh/bandwidth.php
@@ -9,7 +9,7 @@
     sleep(2);
 
     $tx_end = shell_exec($tx_path);
-    $rx_end = shell_exec($rx_path); 
+    $rx_end = shell_exec($rx_path);
 
     $result['tx'] = ($tx_end - $tx_start)/2;
     $result['rx'] = ($rx_end - $rx_start)/2;

--- a/sh/df.php
+++ b/sh/df.php
@@ -1,17 +1,19 @@
-<?php 
+<?php
 
-    exec('/bin/df -h|awk \'{print $1","$2","$3","$4","$5","$6}\'',$result);
+exec('/bin/df -h|awk \'{print $1","$2","$3","$4","$5","$6}\'', $result);
 
-    header('Content-Type: application/json; charset=UTF-8');
-    echo "[";
-    $x = 0;
-    $max = count($result)-1;
-    foreach ($result as $a)
-    {    
-        if ($x==0){ $x++; continue;}
-        echo json_encode( explode(',',$result[$x]) );
-        echo ($x==$max)?'':',';
-        unset($result[$x],$a);
+header('Content-Type: application/json; charset=UTF-8');
+echo "[";
+$x = 0;
+$max = count($result)-1;
+foreach ($result as $a) {
+    if ($x==0) {
         $x++;
+        continue;
     }
-    echo ']';
+    echo json_encode(explode(',', $result[$x]));
+    echo ($x==$max) ? '' : ',';
+    unset($result[$x], $a);
+    $x++;
+}
+echo ']';

--- a/sh/dnsmasq-leases.php
+++ b/sh/dnsmasq-leases.php
@@ -1,45 +1,43 @@
 <?php
 
-    // define the path to the DNSMasq Lease file
-    $dnsmasq_lease_file = "/var/lib/misc/dnsmasq.leases";
+// define the path to the DNSMasq Lease file
+$dnsmasq_lease_file = "/var/lib/misc/dnsmasq.leases";
 
-    // check if DNS MASQ file exists
-    if (file_exists($dnsmasq_lease_file) ){
+// check if DNS MASQ file exists
+if (file_exists($dnsmasq_lease_file)) {
 
-        // get the contents of the lease file
-        $data = file_get_contents($dnsmasq_lease_file);
+    // get the contents of the lease file
+    $data = file_get_contents($dnsmasq_lease_file);
 
-        // separate it into lines
-        $data = explode("\n", $data);
+    // separate it into lines
+    $data = explode("\n", $data);
 
-        // strip any blank lines
-        $data = array_filter($data, function($v){ return $v; });
+    // strip any blank lines
+    $data = array_filter($data, function ($v) {
+        return $v;
+    });
 
-        // build the results
-        $results = array();
+    // build the results
+    $results = array();
 
-        // step through the data
-        foreach( $data as $l )
-        {
-            // explode each line of the data
-            $l = explode(" ", $l);
+    // step through the data
+    foreach ($data as $l) {
+        // explode each line of the data
+        $l = explode(" ", $l);
 
-            // remove the last field (I don't know what it is - for most of the
-            // lines it's simply "*", in other cases it's the host MAC address)
-            unset($l[4]);
+        // remove the last field (I don't know what it is - for most of the
+        // lines it's simply "*", in other cases it's the host MAC address)
+        unset($l[4]);
 
-            // convert the timestamp to a readable date/time
-            $l[0] = date("m/j/Y H:i:s", $l[0]);
+        // convert the timestamp to a readable date/time
+        $l[0] = date("m/j/Y H:i:s", $l[0]);
 
-            // add the line to the results
-            $results[] = $l;
-        } // END foreach
+        // add the line to the results
+        $results[] = $l;
     }
-    // if DNS MASQ file does NOT exist
-    else{
-        $results = array();
-    }
+} else {
+    $results = array();
+}
 
-    // output the results
-    echo json_encode($results);
-
+// output the results
+echo json_encode($results);

--- a/sh/hostname.php
+++ b/sh/hostname.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 
-    header('Content-Type: application/json; charset=UTF-8');
-    echo json_encode(shell_exec('/bin/hostname'));
+header('Content-Type: application/json; charset=UTF-8');
+echo json_encode(shell_exec('/bin/hostname'));

--- a/sh/ip.php
+++ b/sh/ip.php
@@ -1,34 +1,41 @@
 <?php
 
-    // First try to get the IPs using "ip"
-    // First get list of links
-    $command='/bin/ip -oneline link show | /usr/bin/awk \'{print $2}\' | /bin/sed "s/://"';
-    exec($command,$result,$error);
-    if ( $error ) { // It didn't work with "ip" , so we do it with ifconfig
-    exec('/sbin/ifconfig | /bin/grep -B1 "inet addr" | /usr/bin/awk \''.
-        '{ if ( $1 == "inet" ) { print $2 } else if ( $2 == "Link" ) { printf "%s:",$1 } }\' | /usr/bin/awk'.
-        ' -F: \'{ print $1","$3 }\'',$result);
-    }else{
-    $result = implode(' ',$result);
+// First try to get the IPs using "ip"
+// First get list of links
+$command='/bin/ip -oneline link show | /usr/bin/awk \'{print $2}\' | /bin/sed "s/://"';
+exec($command, $result, $error);
+if ($error) { // It didn't work with "ip" , so we do it with ifconfig
+    exec(
+        '/sbin/ifconfig | /bin/grep -B1 "inet addr" | /usr/bin/awk \'' .
+        '{ if ( $1 == "inet" ) { print $2 }' .
+        'else if ( $2 == "Link" ) { printf "%s:",$1 } }\' | /usr/bin/awk' .
+        ' -F: \'{ print $1","$3 }\'',
+        $result
+    );
+} else {
+    $result = implode(' ', $result);
     // Now use that list to get the ip-adresses
-    $command = 'for interface in '.$result.';do for family in inet inet6;do /bin/ip -oneline -family $family addr show $interface | /bin/grep -v fe80 | /usr/bin/awk \'{print $2","$4}\';done;done';
-        exec($command,$result,$return_value);
-    }
-    // Get external adress
-    $result2 = file_get_contents('http://ipecho.net/plain');
+    $command = "for interface in {$result}; do" .
+       ' for family in inet inet6; do'.
+       ' /bin/ip -oneline -family $family addr show $interface |' .
+       ' /bin/grep -v fe80 | /usr/bin/awk \'{print $2","$4}\';' .
+       ' done; done';
+    exec($command, $result, $return_value);
+}
+// Get external adress
+$result2 = file_get_contents('http://ipecho.net/plain');
 
-    // Create JSON header
-    header('Content-Type: application/json; charset=UTF-8');
-    // Return info as JSON
-    echo '[[','"external ip","',$result2,'"]';
-    $x = 0;
-    $max = count($result)-1;
-    foreach ($result as $a)
-    {   echo ',';
-        echo json_encode( explode(',',$result[$x]) );
-        //echo ($x==$max)?'':',';
-        unset($result[$x],$a);
-        $x++;
-    }
-    echo ']';
-    
+// Create JSON header
+header('Content-Type: application/json; charset=UTF-8');
+// Return info as JSON
+echo '[[','"external ip","',$result2,'"]';
+$x = 0;
+$max = count($result)-1;
+foreach ($result as $a) {
+    echo ',';
+    echo json_encode(explode(',', $result[$x]));
+    //echo ($x==$max)?'':',';
+    unset($result[$x],$a);
+    $x++;
+}
+echo ']';

--- a/sh/issue.php
+++ b/sh/issue.php
@@ -1,4 +1,4 @@
 <?php
 
-    header('Content-Type: application/json; charset=UTF-8');
-    echo json_encode(shell_exec('/usr/bin/lsb_release -ds;/bin/uname -r')) ;
+header('Content-Type: application/json; charset=UTF-8');
+echo json_encode(shell_exec('/usr/bin/lsb_release -ds;/bin/uname -r')) ;

--- a/sh/loadavg.php
+++ b/sh/loadavg.php
@@ -1,20 +1,21 @@
-<?php 
-    
-    exec('/bin/grep -c ^processor /proc/cpuinfo',$resultNumberOfCores);
-    $numberOfCores = $resultNumberOfCores[0];
+<?php
 
-    exec('/bin/cat /proc/loadavg | /usr/bin/awk \'{print $1","$2","$3}\'',$resultLoadAvg);
-    $loadAvg = explode(',',$resultLoadAvg[0]);
+exec('/bin/grep -c ^processor /proc/cpuinfo', $resultNumberOfCores);
+$numberOfCores = $resultNumberOfCores[0];
 
-    header('Content-Type: application/json; charset=UTF-8');
-    echo json_encode(
-        array_map(
-            "convertToPercentage",
-            $loadAvg,
-            array_fill(0, count($loadAvg), $numberOfCores)
-        )
-    );
-    
-    function convertToPercentage($value, $numberOfCores){
-        return array($value, (int)($value * 100 / $numberOfCores));
-    }
+exec(
+    '/bin/cat /proc/loadavg | /usr/bin/awk \'{print $1","$2","$3}\'',
+    $resultLoadAvg
+);
+$loadAvg = explode(',', $resultLoadAvg[0]);
+
+header('Content-Type: application/json; charset=UTF-8');
+echo json_encode(
+    array_map(
+        function ($value, $numberOfCores) {
+            return array($value, (int)($value * 100 / $numberOfCores));
+        },
+        $loadAvg,
+        array_fill(0, count($loadAvg), $numberOfCores)
+    )
+);

--- a/sh/mem.php
+++ b/sh/mem.php
@@ -1,9 +1,11 @@
-<?php 
+<?php
 
-    //exec('cat /proc/meminfo|awk \'{print $1","$2}\'',$result);
-    //exec('free -m|awk \'{print $1","$2","$3","$4}\'',$result);
-    exec('/usr/bin/free -tmo | /usr/bin/awk \'{print $1","$2","$3-$6-$7","$4+$6+$7}\'',$result);
+//exec('cat /proc/meminfo|awk \'{print $1","$2}\'',$result);
+//exec('free -m|awk \'{print $1","$2","$3","$4}\'',$result);
+exec(
+    '/usr/bin/free -tmo | /usr/bin/awk \'{print $1","$2","$3-$6-$7","$4+$6+$7}\'',
+    $result
+);
 
-    header('Content-Type: application/json; charset=UTF-8');
-    echo json_encode( explode(',',$result[1]) );
-
+header('Content-Type: application/json; charset=UTF-8');
+echo json_encode(explode(',', $result[1]));

--- a/sh/netstat.php
+++ b/sh/netstat.php
@@ -1,12 +1,22 @@
-<?php 
+<?php
 
-    exec("/bin/netstat -ntu | /usr/bin/awk 'NR>2 {sub(/:[^:]+$/, \"\"); print $5}' | /usr/bin/sort | /usr/bin/uniq -c", $result);
+exec(
+    '/bin/netstat -ntu |' .
+    " /usr/bin/awk 'NR>2 {sub(/:[^:]+$/, \"\"); print $5}' |" .
+    ' /usr/bin/sort | /usr/bin/uniq -c',
+    $result
+);
 
-    header('Content-Type: application/json; charset=UTF-8');
-    echo "[";
-    $max = count($result);
-    for ($i = 0; $i < $max; $i++) {
-        echo json_encode( preg_split('@\s+@', $result[$i], NULL, PREG_SPLIT_NO_EMPTY) );
-        echo ($i + 1 == $max)?'':',';
-    }
-    echo "]";
+header('Content-Type: application/json; charset=UTF-8');
+echo "[";
+$max = count($result);
+for ($i = 0; $i < $max; $i++) {
+    echo json_encode(preg_split(
+        '@\s+@',
+        $result[$i],
+        null,
+        PREG_SPLIT_NO_EMPTY
+    ));
+    echo ($i + 1 == $max)?'':',';
+}
+echo "]";

--- a/sh/numberofcores.php
+++ b/sh/numberofcores.php
@@ -1,28 +1,31 @@
-<?php 
+<?php
 
-    $intOpts = array(
-        'options' => array(
-            'min' => 1,
-        ),
-    );
+$intOpts = array(
+    'options' => array(
+        'min' => 1,
+    ),
+);
 
-    // get value via /proc/cpuinfo
-    $numOfCores = shell_exec('/bin/grep -c ^processor /proc/cpuinfo');
-    $numOfCores = filter_var($numOfCores[0],
+// get value via /proc/cpuinfo
+$numOfCores = shell_exec('/bin/grep -c ^processor /proc/cpuinfo');
+$numOfCores = filter_var(
+    $numOfCores[0],
+    FILTER_VALIDATE_INT,
+    $intOpts
+);
+
+// If number of cores is not found, run fallback
+if ($numOfCores === false) {
+    $numOfCores = filter_var(
+        shell_exec('/usr/bin/nproc'),
         FILTER_VALIDATE_INT,
-        $intOpts);
+        $intOpts
+    );
+}
 
-    // If number of cores is not found, run fallback
-    if( $numOfCores === false ){
-        $numOfCores = filter_var(shell_exec('/usr/bin/nproc'),
-            FILTER_VALIDATE_INT,
-            $intOpts);
-    }
+if ($numOfCores === false) {
+    $numOfCores = 'unknown';
+}
 
-    if( $numOfCores === false ){
-        $numOfCores = 'unknown';
-    }
-
-    header('Content-Type: application/json; charset=UTF-8');
-    echo json_encode( $numOfCores );
-    
+header('Content-Type: application/json; charset=UTF-8');
+echo json_encode($numOfCores);

--- a/sh/online.php
+++ b/sh/online.php
@@ -1,13 +1,16 @@
-<?php 
+<?php
 
-    // change username column length for w command
-    putenv("PROCPS_USERLEN=20");
-    exec('PROCPS_FROMLEN=40 /usr/bin/w -h | /usr/bin/awk \'{print $1","$3","$4","$5}\'',$users);
-    $result = array();
-    foreach ($users as $user)
-    {
-        $result[] = explode(",", $user);
-    }
+// change username column length for w command
+putenv("PROCPS_USERLEN=20");
+exec(
+    'PROCPS_FROMLEN=40 /usr/bin/w -h |' .
+    ' /usr/bin/awk \'{print $1","$3","$4","$5}\'',
+    $users
+);
+$result = array();
+foreach ($users as $user) {
+    $result[] = explode(",", $user);
+}
 
-    header('Content-Type: application/json; charset=UTF-8');
-    echo json_encode($result);
+header('Content-Type: application/json; charset=UTF-8');
+echo json_encode($result);

--- a/sh/ping.php
+++ b/sh/ping.php
@@ -1,23 +1,25 @@
 <?php
-    header('Content-Type: application/json; charset=UTF-8');
+header('Content-Type: application/json; charset=UTF-8');
 
-    // Read list of hosts to ping from csv file ping_hosts
-    if (file_exists("ping_hosts")) {
-        $hosts = file('ping_hosts', FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
-    }
-    // If file doesn't exist then use hard coded list
-    else {
-        $hosts = array("gnu.org", "github.com", "wikipedia.org");
-    }
+// Read list of hosts to ping from csv file ping_hosts
+if (file_exists("ping_hosts")) {
+    $hosts = file('ping_hosts', FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+} else {
+    $hosts = array("gnu.org", "github.com", "wikipedia.org");
+}
 
-    $pingCount = 2;
+$pingCount = 2;
 
-    echo "[";
-    $max = count($hosts);
-    for ($i = 0; $i < $max; $i++) {
-        $result = array();
-        exec("/bin/ping -qc ". $pingCount ." " . $hosts[$i] . " | awk -F/ '/^rtt/ { print $5 }'", $result);
-        echo json_encode(array($hosts[$i], $result[0]));
-        echo ($i + 1 == $max)?'':',';
-    }
-    echo "]";
+echo "[";
+$max = count($hosts);
+for ($i = 0; $i < $max; $i++) {
+    $result = array();
+    exec(
+        "/bin/ping -qc {$pingCount} {$hosts[$i]} |" .
+        " awk -F/ '/^rtt/ { print $5 }'",
+        $result
+    );
+    echo json_encode(array($hosts[$i], $result[0]));
+    echo ($i + 1 == $max) ? '' : ',';
+}
+echo "]";

--- a/sh/ps.php
+++ b/sh/ps.php
@@ -1,18 +1,21 @@
 <?php
 
-    // Execute top command on server to get results of ps aux
-    // each row (including header) is in csv format
-    exec('/bin/ps aux | /usr/bin/awk '."'NR>1{print ".'$1","$2","$3","$4","$5","$6","$7","$8","$9","$10","$11'."}'", $result);
-    
-    header('Content-Type: application/json; charset=UTF-8');
-    echo "[";
-    $x = 0;
-    $max = count($result)-1;
-    foreach ($result as $a)
-    {    
-        echo json_encode( explode(',',$result[$x]) );
-        echo ($x==$max)?'':',';
-        unset($result[$x],$a);
-        $x++;
-    }
-    echo ']';
+// Execute top command on server to get results of ps aux
+// each row (including header) is in csv format
+exec(
+    '/bin/ps aux | /usr/bin/awk ' .
+    "'NR>1{print ".'$1","$2","$3","$4","$5","$6","$7","$8","$9","$10","$11'."}'",
+    $result
+);
+
+header('Content-Type: application/json; charset=UTF-8');
+echo "[";
+$x = 0;
+$max = count($result)-1;
+foreach ($result as $a) {
+    echo json_encode(explode(',', $result[$x]));
+    echo ($x==$max)?'':',';
+    unset($result[$x],$a);
+    $x++;
+}
+echo ']';

--- a/sh/speed.php
+++ b/sh/speed.php
@@ -1,73 +1,72 @@
 <?php
 
-    define('MB', 1000000);
+$mb = 1000000;
 
-    /*
-     * This array exist just to give some choice and flexibility to the user.
-     * A big(~10MB) CDN hosted( e.g CloudFlare ) blob would be preferable for high availability and consistent performance.
-     */
-    $hosts = array(
-        0 => array(
-            /* IPv4 & IPv6 Port: 80, 81, 8080 IPv6 */
-            'hostname' => 'download.thinkbroadband.com',
-            'resource' => '/10MB.zip',
-            'size' => 10, //MB
-            'timeout' => 30,
-        ),
-        1 => array(
-            'hostname' => 'cachefly.cachefly.net',
-            'resource' => '/10mb.test',
-            'size' => 10, //MB
-            'timeout' => 30,
-        ),
-        2 => array(
-            /* Download 10MB file from Seattle */
-            'hostname' => 'speedtest.sea01.softlayer.com',
-            'resource' => '/downloads/test10.zip',
-            'size' => 10, //MB
-            'timeout' => 30,
-        ),
-        3 => array(
-            /* 50 MB */
-            'hostname' => 'download.thinkbroadband.com',
-            'resource' => '/50MB.zip',
-            'size' => 50, //MB
-            'timeout' => 120,
-        ),
-    );
+/*
+ * This array exist just to give some choice and flexibility to the user.
+ * A big(~10MB) CDN hosted( e.g CloudFlare ) blob would be preferable for high availability and consistent performance.
+ */
+$hosts = array(
+    0 => array(
+        /* IPv4 & IPv6 Port: 80, 81, 8080 IPv6 */
+        'hostname' => 'download.thinkbroadband.com',
+        'resource' => '/10MB.zip',
+        'size' => 10, //MB
+        'timeout' => 30,
+    ),
+    1 => array(
+        'hostname' => 'cachefly.cachefly.net',
+        'resource' => '/10mb.test',
+        'size' => 10, //MB
+        'timeout' => 30,
+    ),
+    2 => array(
+        /* Download 10MB file from Seattle */
+        'hostname' => 'speedtest.sea01.softlayer.com',
+        'resource' => '/downloads/test10.zip',
+        'size' => 10, //MB
+        'timeout' => 30,
+    ),
+    3 => array(
+        /* 50 MB */
+        'hostname' => 'download.thinkbroadband.com',
+        'resource' => '/50MB.zip',
+        'size' => 50, //MB
+        'timeout' => 120,
+    ),
+);
 
-    $chosenHost = 1;
-    $hostname = $hosts[$chosenHost]['hostname'];
-    $resource = $hosts[$chosenHost]['resource'];
-    $size = $hosts[$chosenHost]['size'] * MB;
-    $timeout = $hosts[$chosenHost]['timeout'];
-    $port = 80;
+$chosenHost = 1;
+$hostname = $hosts[$chosenHost]['hostname'];
+$resource = $hosts[$chosenHost]['resource'];
+$size = $hosts[$chosenHost]['size'] * $mb;
+$timeout = $hosts[$chosenHost]['timeout'];
+$port = 80;
 
-    $out = "GET {$resource} HTTP/1.1\r\n";
-    $out .= "Host: {$hostname}\r\n";
-    $out .= "Connection: Close\r\n\r\n";
-    $chunkSize = 1024;
+$out = "GET {$resource} HTTP/1.1\r\n";
+$out .= "Host: {$hostname}\r\n";
+$out .= "Connection: Close\r\n\r\n";
+$chunkSize = 1024;
 
-    $end = null;
-    $speed = 0;
-    $start = microtime(true);
+$end = null;
+$speed = 0;
+$start = microtime(true);
 
-    $fp = fsockopen($hostname, $port, $errno, $errstr, $timeout);
-    if (!$fp) {
-        echo "$errstr ($errno)<br />\n";
-    } else {
-        fwrite($fp, $out);
-        while (!feof($fp)) {
-            fread($fp, $chunkSize);
-        }
-        $end = microtime(true);
-        fclose($fp);
-
-        $time = $end - $start;
-        if ($time) {
-            $speed = ($size / $time);
-        }
+$fp = fsockopen($hostname, $port, $errno, $errstr, $timeout);
+if (!$fp) {
+    echo "$errstr ($errno)<br />\n";
+} else {
+    fwrite($fp, $out);
+    while (!feof($fp)) {
+        fread($fp, $chunkSize);
     }
+    $end = microtime(true);
+    fclose($fp);
 
-    echo json_encode($speed);
+    $time = $end - $start;
+    if ($time) {
+        $speed = ($size / $time);
+    }
+}
 
+echo json_encode($speed);

--- a/sh/uptime.php
+++ b/sh/uptime.php
@@ -1,25 +1,25 @@
 <?php
 
-    $totalSeconds = shell_exec("/usr/bin/cut -d. -f1 /proc/uptime");
-    $totalMin   = $totalSeconds / 60;
-    $totalHours = $totalMin / 60;
+$totalSeconds = shell_exec("/usr/bin/cut -d. -f1 /proc/uptime");
+$totalMin   = $totalSeconds / 60;
+$totalHours = $totalMin / 60;
 
-    $days  = floor($totalHours / 24);
-    $hours = floor($totalHours - ($days * 24));
-    $min   = floor($totalMin - ($days * 60 * 24) - ($hours * 60));
+$days  = floor($totalHours / 24);
+$hours = floor($totalHours - ($days * 24));
+$min   = floor($totalMin - ($days * 60 * 24) - ($hours * 60));
 
-    $formatUptime = '';
-    if ($days != 0) {
-        $formatUptime .= "$days days ";
-    }
+$formatUptime = '';
+if ($days != 0) {
+    $formatUptime .= "$days days ";
+}
 
-    if ($hours != 0) {
-        $formatUptime .= "$hours hours ";
-    }
+if ($hours != 0) {
+    $formatUptime .= "$hours hours ";
+}
 
-    if ($min != 0) {
-        $formatUptime .= "$min minutes";
-    }
+if ($min != 0) {
+    $formatUptime .= "$min minutes";
+}
 
-    header('Content-Type: application/json; charset=UTF-8');
-    echo json_encode($formatUptime);
+header('Content-Type: application/json; charset=UTF-8');
+echo json_encode($formatUptime);

--- a/sh/users.php
+++ b/sh/users.php
@@ -1,17 +1,22 @@
-<?php 
+<?php
 
-    exec('/usr/bin/awk -F: \'{ if ($3<=499) print "system,"$1","$6; else print "user,"$1","$6; }\' < /etc/passwd',$result);
-    
-    header('Content-Type: application/json; charset=UTF-8');
-    echo "[";
-    $x = 0;
-    $max = count($result)-1;
-    foreach ($result as $a)
-    {   
-        $x++; 
-        $line = explode(',', $a);
-        if($line[1][0] == '#') continue;
-        echo json_encode( $line );
-        echo ($x-1==$max)?'':',';
+exec(
+    '/usr/bin/awk -F: \'{ if ($3<=499) print "system,"$1","$6;' .
+    ' else print "user,"$1","$6; }\' < /etc/passwd',
+    $result
+);
+
+header('Content-Type: application/json; charset=UTF-8');
+echo "[";
+$x = 0;
+$max = count($result)-1;
+foreach ($result as $a) {
+    $x++;
+    $line = explode(',', $a);
+    if ($line[1][0] == '#') {
+        continue;
     }
-    echo ']';
+    echo json_encode($line);
+    echo ($x-1==$max)?'':',';
+}
+echo ']';

--- a/sh/where.php
+++ b/sh/where.php
@@ -1,25 +1,20 @@
 <?php
 
-    // Read list of programs to check from a list
-    if (file_exists("monitor"))
-    {
-        $data = file_get_contents("monitor");
-        $binaries = explode(" ", $data);
-    }
-    // If file doesn't exist then use hard coded list
-    else
-    {	
-    	$binaries = explode(" ", "php node mysql vim python ruby java apache2 nginx openssl vsftpd make");
-    }
+// Read list of programs to check from a list
+if (file_exists("monitor")) {
+    $data = file_get_contents("monitor");
+    $binaries = explode(" ", $data);
+} else { // If file doesn't exist then use hard coded list
+    $binaries = explode(" ", "php node mysql vim python ruby java apache2 nginx openssl vsftpd make");
+}
 
-    putenv('PATH=/usr/local/sbin:/usr/sbin:/sbin:' . getenv('PATH'));
-    $data = array();
-    foreach($binaries as $b)
-    { 
-        $which = array();
-        exec('command -v ' . escapeshellarg($b), $which, $return_var);
-        $data[] = array($b, $return_var ? "Not Installed" : $which[0]);
-    }
+putenv('PATH=/usr/local/sbin:/usr/sbin:/sbin:' . getenv('PATH'));
+$data = array();
+foreach ($binaries as $b) {
+    $which = array();
+    exec('command -v ' . escapeshellarg($b), $which, $return_var);
+    $data[] = array($b, $return_var ? "Not Installed" : $which[0]);
+}
 
-    header('Content-Type: application/json; charset=UTF-8');
-    echo json_encode($data);
+header('Content-Type: application/json; charset=UTF-8');
+echo json_encode($data);


### PR DESCRIPTION
With two exceptions this is supposed to be a purely stylistic change with no functional implications. It achieves full PSR-2 compliance as reported by PHP_CodeSniffer.

The choice of PSR-2 is mainly one of practicality. It is mostly a modern standard and by virtue of being PSR it is well known, and it is used by several mainstream frameworks.

On Debian systems,

```
sudo apt-get install php-pear && sudo pear install PHP_CodeSniffer
```

will install the phpcs binary along with a handful of standards, including PSR-2. It can then be invoked to print to stdout with

```
phpcs --standard=PSR2 sh
```

PHP_CodeSniffer's default standard is PEAR. You can change this with

```
sudo phpcs --config-set default_standard PSR2
```

and henceforth simply call

```
phpcs sh
```

Unfortunately PHP_CodeSniffer does not support project specific configuration settings, so it isn't possible to distribute these.

The two exceptions are warnings concerning mixing symbol definition and logic. One file defined a runtime constant, another a convenience function. Because of linux-dash's current architecture these definitions should have had no impact on program behaviour outside their respective files and so could be safely left in. I opted to resolve the warnings anyway because
1. the warnings are good advice;
2. there would be virtually no runtime or maintenance cost;
3. it achieves full PSR-2 compliance to the extent we can verify;
4. it makes invoking phpcs as simple as possible; and
5. there are no side effects from skipping the relevant sniffs.
