### PR TITLE
Stray spaces in sh/monitor resulted in empty lines in software list

### DIFF
--- a/sh/where.php
+++ b/sh/where.php
@@ -4,7 +4,7 @@
     if (file_exists("monitor"))
     {
         $data = file_get_contents("monitor");
-        $binaries = explode(" ", $data);
+        $binaries = preg_split('~ ~', $data, NULL, PREG_SPLIT_NO_EMPTY);
     }
     // If file doesn't exist then use hard coded list
     else


### PR DESCRIPTION
Sloppy spacing in sh/monitor could result in empty lines in the software list. This fixes without affecting backward compatibility.
