### PR TITLE
Fix min_range option to stop /sh/numberofcpucores.php returning 0

### DIFF
--- a/sh/numberofcores.php
+++ b/sh/numberofcores.php
@@ -2,7 +2,7 @@
 
 $intOpts = array(
     'options' => array(
-        'min' => 1,
+        'min_range' => 1,
     ),
 );
 


### PR DESCRIPTION
The minimum options for filter_var() with FILTER_VALIDATE_INT should me
min_range.
