### PR TITLE
missed /usr/bin in path in where, for Ubuntu 12.04 LTS

### DIFF
--- a/sh/where.php
+++ b/sh/where.php
@@ -12,7 +12,7 @@
     	$binaries = explode(" ", "php node mysql vim python ruby java apache2 nginx openssl vsftpd make");
     }
 
-putenv('PATH=/usr/local/sbin:/usr/sbin:/sbin:' . getenv('PATH'));
+putenv('PATH=/usr/bin:/usr/local/sbin:/usr/sbin:/sbin:' . getenv('PATH'));
 $data = array();
 foreach ($binaries as $b) {
     $which = array();


### PR DESCRIPTION
My dashboard just gave me "Not installed" on all software, by adding /usr/bin to the path in where this fixed it.

Elementary OS, based on Ubuntu 12.04
