### PR TITLE
Moved a media-query rule for .subnavbar-inner

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1164,11 +1164,7 @@ width: 11px;}
 		margin-left: -20px;
 		margin-right: -20px;	
 	}
-	
-	
-	.subnavbar-inner {
-		height: auto;
-	}
+
 	
 	.subnavbar .container > ul {
 		width: 100%;
@@ -1264,6 +1260,10 @@ width: 11px;}
 	
 	.subnavbar .container {		
 		width: auto;
+	}
+
+	.subnavbar-inner {
+		height: auto;
 	}
 
 	.widget-header {


### PR DESCRIPTION
Moved a media-query rule for .subnavbar-inner to the max-width: 979 area instead of max-width: 767 area.

Because the .subnavbar-inner was being blanked out for the btn-navbar (the "hamburger" menu in top right), but the .subnavbar-inner was still there.  This way it goes away when it is blanked out.
