### PR TITLE
POSIX compliant `df -Ph` to suppress linebreaks

### DIFF
--- a/sh/df.php
+++ b/sh/df.php
@@ -1,6 +1,6 @@
 <?php
 
-exec('/bin/df -h|awk \'{print $1","$2","$3","$4","$5","$6}\'', $result);
+exec('/bin/df -Ph|awk \'{print $1","$2","$3","$4","$5","$6}\'', $result);
 
 header('Content-Type: application/json; charset=UTF-8');
 echo "[";


### PR DESCRIPTION
By default `df -h` prints line breaks causing to [misbehave](http://askubuntu.com/questions/55702/df-h-command-puts-line-breaks-in-output-how-do-i-fix) Disk Usage widget.
