### PR TITLE
bandwidth use first interface not eth0

### DIFF
--- a/index.html
+++ b/index.html
@@ -328,7 +328,7 @@
                                 </div><!-- /widget-header -->
                                 <div class="widget-content">
                                     <div style="padding:10px;text-align:center;">
-                                        RX: <span class="lead odometer" style="margin-top:11px;" id="bw-rx">0</span>&nbsp;&nbsp;|&nbsp;&nbsp; TX: <span class="lead odometer" style="margin-top:11px;" id="bw-tx"></span>
+                                        <i style="color:#19bc9c; font:20px/2em 'Open Sans',sans-serif;" class="icon-#" id="bw-int">eth0:</i>&nbsp; RX: <span class="lead odometer" style="margin-top:11px;" id="bw-rx">0</span>&nbsp;&nbsp;|&nbsp;&nbsp; TX: <span class="lead odometer" style="margin-top:11px;" id="bw-tx"></span>
                                     </div>
                                 </div><!-- /widget-content -->
                             </div><!-- /widget -->

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -483,8 +483,9 @@ dashboard.getBandwidth = function () {
         cache: false,
         dataType: 'json',
         success: function (data) {
-            $('#bw-tx').text(data.tx);
-            $('#bw-rx').text(data.rx);
+            $('#bw-int').text(data['0'].interface + ":");
+            $('#bw-tx').text(data['0'].tx);
+            $('#bw-rx').text(data['0'].rx);
         },
         complete: function() {
             refreshIcon.removeClass('icon-spin');

--- a/sh/bandwidth.php
+++ b/sh/bandwidth.php
@@ -1,17 +1,33 @@
 <?php
+    $interface_path = 'ls /sys/class/net'; 
 
-    $tx_path = 'cat /sys/class/net/eth0/statistics/tx_bytes';
-    $rx_path = 'cat /sys/class/net/eth0/statistics/rx_bytes';
+    $interfaces = explode("\n", shell_exec($interface_path));
+    array_pop($interfaces);
+    $key = array_search("lo", $interfaces);
+    unset($interfaces[$key]);
 
-    $tx_start = intval(shell_exec($tx_path));
-    $rx_start = intval(shell_exec($rx_path));
+    $results = array();
 
-    sleep(2);
+    sleep(5);
 
-    $tx_end = intval(shell_exec($tx_path));
-    $rx_end = intval(shell_exec($rx_path));
+    foreach ($interfaces as $interface) {
 
-    $result['tx'] = ($tx_end - $tx_start);
-    $result['rx'] = ($rx_end - $rx_start);
+        $tx_path = "cat /sys/class/net/{$interface}/statistics/tx_bytes";
+        $rx_path = "cat /sys/class/net/{$interface}/statistics/rx_bytes";
 
-    echo json_encode($result);
+        $tx_start = intval(shell_exec($tx_path));
+        $rx_start = intval(shell_exec($rx_path));
+
+        sleep(2);
+
+        $tx_end = intval(shell_exec($tx_path));
+        $rx_end = intval(shell_exec($rx_path));
+
+        $result['interface'] = $interface;
+        $result['tx'] = ($tx_end - $tx_start);
+        $result['rx'] = ($rx_end - $rx_start);
+
+        $results[] = $result;
+    }
+
+    echo json_encode($results);


### PR DESCRIPTION
Rewrote the code to return the bandwidth usage on all interfaces regardless of name however I'm only displaying the first one I'll leave it up to you if you want to display all of them or create a new bandwidth widget for each one.

Closes #172 
