### PR TITLE
Fix arp module behaviour

### DIFF
--- a/libs/Modules/arp.php
+++ b/libs/Modules/arp.php
@@ -7,9 +7,9 @@
 
         public function getData($args=array()) {
 
-	    exec('/usr/sbin/arp | awk \'BEGIN {OFS=","} {print $1,$2,$3,$4,$5}\'', $result);
+	    exec('if [ -e /usr/sbin/arp ] ; then /usr/sbin/arp ; else /sbin/arp ; fi | awk \'BEGIN {OFS=","} {print $1,$2,$3,$4,$5}\'', $result);
 
-	    $data = [];
+	    $data = array();
 	    $x = 0;
 
 	    foreach ($result as $a) {


### PR DESCRIPTION
Change the array initialization in the arp module from [] to array() to stop a 500 exception from appearing an php 5.3.

Also, check if the arp executable is in /usr/sbin/arp and if not found fall back to /sbin/arp.
