### PR TITLE
Stop previous animations before starting new

### DIFF
--- a/js/base.js
+++ b/js/base.js
@@ -17,7 +17,7 @@ $(document).ready(function() {
     var target = $(this.hash).parent();
     pulseElement(target, 8, 400);
 
-    $("html,body").animate({
+    $("html,body").stop().animate({
         scrollTop: target.offset().top - 130
     }, 1000);
 }).on("click", ".js-refresh-info", function(event) {


### PR DESCRIPTION
If you click quickly each link of navbar you get all of them animating one-by-one. It'd be better to clear queue and start only last.

http://api.jquery.com/stop/
