### PR TITLE
Added missing requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ Visit [linuxdash.com](http://www.linuxdash.com/) to view demo and full documenta
 
 1. Make sure you have `php5-json` installed and enabled
 2. Make sure you have the `exec`, `shell_exec`, and `escapeshellarg` functions enabled
-2. [Download the source](https://github.com/afaqurk/linux-dash/archive/master.zip) or clone the repo 
-3. Place it in `/var/www/` (for Apache); For nginx setup, see [this gist](https://gist.github.com/sergeifilippov/8909839) by [@sergeifilippov](https://github.com/sergeifilippov)
+3. [Download the source](https://github.com/afaqurk/linux-dash/archive/master.zip) or clone the repo 
+4. Place it in `/var/www/` (for Apache); For nginx setup, see [this gist](https://gist.github.com/sergeifilippov/8909839) by [@sergeifilippov](https://github.com/sergeifilippov)
 
 **Please note: If you would like to limit access to linux-dash, please add
 `.htaccess` or other security measure.**


### PR DESCRIPTION
Issue #254 requests that the missing required functions `exec`, `shell_exec`, and `escapeshellarg` be added to the README.

This pull request does that by adding an extra step under 'Installation'.

This is also my first ever pull request on github.

Screenshot:
![linux-dash commit screenshot](https://cloud.githubusercontent.com/assets/9929737/5234104/b4762aa4-77ad-11e4-91b9-53662973d57b.png)
