### PR TITLE
Makes ping module ipv6-enabled.

### DIFF
--- a/libs/Modules/ping.php
+++ b/libs/Modules/ping.php
@@ -26,6 +26,15 @@
                     $result
                 );
                 
+		if (empty($result[0])) {
+			// Empty, so maybe it's an IPv6-only host, so run ping6
+			exec(
+				"/bin/ping6 -qc {$pingCount} {$hosts[$i]} |" .
+				" awk -F/ '/^rtt/ { print $5 }'",
+				$result
+			);
+		} // if
+
                 $pingTime = (empty($result[0]))? 'could not reach host': $result[0] . ' ms';
                 
                 $data[] = array( 


### PR DESCRIPTION
Makes the ping module ipv6-enabled. Tested with ipv6.google.com and newszilla6.xs4all.nl in ping_hosts and a working ipv6 setup
