### PR TITLE
Update free shell command usage for actual available RAM.

### DIFF
--- a/server/modules/shell_files/current_ram.sh
+++ b/server/modules/shell_files/current_ram.sh
@@ -6,7 +6,7 @@ awkCmd=`which awk`
 procps=$($freeCmd -V | /bin/grep procps-ng)
 
 if [ -z "$procps" ]; then
-	$freeCmd -tmo | $awkCmd 'NR==2 {print "{ \"total\": " $2 ", \"used\": " $3 ", \"free\": " $4 " }"}'
+	$freeCmd -tmo | $awkCmd 'NR==2 {print "{ \"total\": " $2 ", \"used\": " $3-$6-$7 ", \"free\": " $4+$6+$7 " }"}'
 else
-	$freeCmd -tm | $awkCmd 'NR==2 {print "{ \"total\": " $2 ", \"used\": " $3 ", \"free\": " $4 " }"}'
+	$freeCmd -tm | $awkCmd 'NR==2 {print "{ \"total\": " $2 ", \"used\": " $3-$6-$7 ", \"free\": " $4+$6+$7 " }"}'
 fi


### PR DESCRIPTION
Please see http://www.linuxatemyram.com/ for a discussion on how to properly compute the available RAM in a system. Essentially, the Buffers and Cached fields are free for the system's use at any time.