### PR TITLE
Fix getKB() to work with partition sizes > 1TiB

### DIFF
--- a/js/modules.js
+++ b/js/modules.js
@@ -24,8 +24,13 @@ linuxDash.directive('diskSpace', ['server', function(server) {
                     size = parseInt(stringSize);
 
                 switch (lastChar){
-                    case 'M': return size * 1024;
-                    case 'G': return size * 1048576;
+                    case 'M': return size * Math.pow(1024, 1);
+                    case 'G': return size * Math.pow(1024, 2);
+                    case 'T': return size * Math.pow(1024, 3);
+                    case 'P': return size * Math.pow(1024, 4);
+                    case 'E': return size * Math.pow(1024, 5);
+                    case 'Z': return size * Math.pow(1024, 6);
+                    case 'Y': return size * Math.pow(1024, 7);
                     default: return size;
                 }
             };


### PR DESCRIPTION
getKB() previously only understood 'G' and 'M' as postfixes of human-readable partition sizes. 
Future-proofed to work for all SI prefixes up to Yottabyte (as supported by df -h).