### PR TITLE
fix network chart delay

### DIFF
--- a/js/linuxDash.js
+++ b/js/linuxDash.js
@@ -358,7 +358,8 @@ linuxDash.directive('multiLineChartPlugin', ['$interval', '$compile', 'server', 
         moduleName: '@',
         refreshRate: '=',
         getDisplayValue: '=',
-        units: '='
+        units: '=',
+        delay: '='
     },
     templateUrl: 'templates/app/multi-line-chart-plugin.html',
     link: function (scope, element) {


### PR DESCRIPTION
Fix for the mentioned "smoothieness" in #304 to let it honor scope.delay settings in the modules.js and return a value for angular.isDefined when it is defined.