### PR TITLE
Fix multiple lists in navbar.

### DIFF
--- a/templates/app/navbar.html
+++ b/templates/app/navbar.html
@@ -1,6 +1,6 @@
 <br>
-<ul ng-repeat="navItem in items">
-    <li ng-class="{active: isActive(navItem) }">
+<ul>
+    <li ng-class="{active: isActive(navItem) }" ng-repeat="navItem in items">
         <a href="#/{{navItem}}">
             {{getNavItemName(navItem)}}
         </a>


### PR DESCRIPTION
There's a bug in the current version's navbar : it displays several lists with a single item in each instead of a single list with several items (which I believe is the intended behaviour).

This commit just moves the `ng-repeat` directive to the `li` level to fix it.