### PR TITLE
Fixing graph resizing issue

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -92,7 +92,7 @@ body {
 #theme-switcher {
   position: fixed;
   top: 25px;
-  right: -375px;
+  right: -320px;
   border-radius: 5px 0px 0px 5px;
   padding: 4px;
   z-index: 999999;
@@ -339,6 +339,8 @@ table.metrics-table {
 canvas {
   float: none;
   margin: 0 auto;
+  height: 30%;
+  width: 70%;
 }
 /*********************************************
     Widget Elements

--- a/templates/app/line-chart-plugin.html
+++ b/templates/app/line-chart-plugin.html
@@ -4,7 +4,7 @@
 	
 	<div class="plugin-body no-padding">
 
-		<canvas class="canvas" width="300" height="200"></canvas>
+		<canvas class="canvas"></canvas>
 
 		<table border="0" class="metrics-table">
 			<tbody>

--- a/templates/app/multi-line-chart-plugin.html
+++ b/templates/app/multi-line-chart-plugin.html
@@ -3,7 +3,7 @@
 	
 	<div class="plugin-body no-padding">
 
-		<canvas class="canvas" width="300" height="200"></canvas>
+		<canvas class="canvas"></canvas>
 
 		<table class="metrics-table" border="0">
 			<tbody>


### PR DESCRIPTION
Whenever the web browser is zoomed or minimized, the graph resizes abnormally until it disappears completely.

I have removed the height and width inline property inside the canvas
multi-line-chart-plugin
line-chart-plugin

and added them as percentage in main.css under canvas

I guess, after this the problem got fixed.