### PR TITLE
Provide full path to modules directory

### DIFF
--- a/server/index.php
+++ b/server/index.php
@@ -1,8 +1,8 @@
 <?php
 	header("Cache-Control: no-store, no-cache, must-revalidate");
-    header("Pragma: no-cache");
+	header("Pragma: no-cache");
 
-	$modules_dir = 'modules/shell_files/';
+	$modules_dir = dirname(__FILE__) . '/modules/shell_files/';
 	$module = escapeshellcmd($_GET['module']);
 
 	echo shell_exec( $modules_dir . $module . '.sh' );


### PR DESCRIPTION
On some installation this won't work fine, but providing full path fixes the issues of relative paths.
