### PR TITLE
Implement websockets in client and nodejs server

### DIFF
--- a/js/linuxDash.js
+++ b/js/linuxDash.js
@@ -50,12 +50,31 @@ linuxDash.service('serverAddress', ['$q', function ($q) {
 var websocket = null;
 var websocketCallbacks = {};
 var websocketRequests = [];
+var websocketSupported = 'unknown';
+
 /**
  * Gets data from server and runs callbacks on response.data.data 
  */
 linuxDash.service('server', ['$http', function ($http) {
     this.get = function (moduleName, callback) {
-        if (window.WebSocket) {
+
+        //Query websocket support status, can be removed once all backends support websockets
+        if (window.WebSocket && websocketSupported === 'unknown') {
+            $http.get("/websocket").then(function () {
+                websocketSupported = 'yes';
+            }, function() {
+                websocketSupported = 'no';
+            });
+        }
+        if (window.WebSocket && websocketSupported === 'yes') {
+            //Query websocket support status, can be removed once all backends support websockets
+            if (websocketSupported == 'unknown') {
+                $http.get("/websocket").then(function () {
+                    websocketSupported = 'yes';
+                }, function() {
+                    websocketSupported = 'no';
+                });
+            }
             if (websocket == null) {
                 websocket = new WebSocket('ws://' + window.location.hostname + ':' + window.location.port, 'linux-dash');
                 websocket.onopen = function() {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "homepage": "https://github.com/afaqurk/linux-dash",
   "dependencies": {
-    "express": "^4.11.1"
+    "express": "^4.11.1",
+    "websocket": "^1.0.22"
   }
 }

--- a/server/index.js
+++ b/server/index.js
@@ -4,6 +4,7 @@ var server 	= require('http').Server(app);
 var path 	= require('path');
 var spawn 	= require('child_process').spawn;
 var fs 		= require('fs');
+var ws      = require('websocket').server;
 
 server.listen(80);
 console.log('Linux Dash Server Started!');
@@ -14,13 +15,50 @@ app.get('/', function (req, res) {
 	res.sendFile(path.resolve(__dirname + '/../index.html'));
 });
 
+wsServer = new ws({
+	httpServer: server
+});
+
+wsServer.on('request', function(request) {
+	var connection = request.accept('linux-dash', request.origin);
+	connection.on('message', function(message) {
+        if (message.type === 'utf8') {
+			var req = JSON.parse(message.utf8Data)
+
+			var shellFile = __dirname + '/modules/shell_files/' + req.module + '.sh';
+
+			if (req.module.indexOf('.') > -1
+				|| !req.module
+				|| !fs.existsSync(shellFile))
+			{
+				res.sendStatus(406);
+				return;
+			}
+
+			var command = spawn(shellFile, [ req.color || '' ]);
+			var output  = [];
+
+			command.stdout.on('data', function(chunk) {
+				output.push(chunk);
+			});
+
+			command.on('close', function(code) {
+				if (code === 0) {
+					req.output = output.toString();
+					connection.sendUTF(JSON.stringify(req));
+				}
+			});
+        }
+    });
+});
+
 app.get('/server/', function (req, res) {
 
 	var shellFile = __dirname + '/modules/shell_files/' + req.query.module + '.sh';
 
-	if (req.query.module.indexOf('.') > -1 
-		|| !req.query.module 
-		|| !fs.existsSync(shellFile)) 
+	if (req.query.module.indexOf('.') > -1
+		|| !req.query.module
+		|| !fs.existsSync(shellFile))
 	{
 		res.sendStatus(406);
 		return;

--- a/server/index.js
+++ b/server/index.js
@@ -15,6 +15,10 @@ app.get('/', function (req, res) {
 	res.sendFile(path.resolve(__dirname + '/../index.html'));
 });
 
+app.get('/websocket', function (req, res) {
+	res.status(200).send("");
+});
+
 wsServer = new ws({
 	httpServer: server
 });


### PR DESCRIPTION
Open to suggestions / improvements. What this PR implements:

* Client side support of data requests via websocket (any backend can implement websockets and have the client use them)
* Fallback to XHR if websockets are not supported by the browser
* Fallback to XHR if the linux-dash server does not support websockets (for Go & PHP currently)
* Automatic websocket reconnection on disconnect
* NodeJS server websocket implementation

The websocket messages are UTF8 strings of JSON data.