### PR TITLE
add #!/bin/bash to ip_addresses.sh

### DIFF
--- a/server/modules/shell_files/ip_addresses.sh
+++ b/server/modules/shell_files/ip_addresses.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 awkCmd=`which awk`
 grepCmd=`which grep`
 sedCmd=`which sed`


### PR DESCRIPTION
Error executing 'modules/shell_files/ip_addresses.sh': fork/exec modules/shell_files/ip_addresses.sh: exec format error

解决方案：
在ip_addresses.sh文件首行添加#!/bin/bash