### PR TITLE
fix https://github.com/afaqurk/linux-dash/issues/353

### DIFF
--- a/js/modules.js
+++ b/js/modules.js
@@ -27,7 +27,7 @@
 
         scope.getKB = function(stringSize) {
           var lastChar = stringSize.slice(-1),
-            size = parseInt(stringSize);
+            size = parseFloat(stringSize.replace(",", "."));
 
           switch (lastChar) {
             case 'M':


### PR DESCRIPTION
Fix for issue https://github.com/afaqurk/linux-dash/issues/353 - when we use "parseInt" for not very different values (like issue case) we've got a zero  values delta because "parseInt" return 1 for all values (for 1,2  and for 1,8). And we must use dot as separator, but my Debian return numbers with semicolon separator (i think it's localization feature, but "replace" not prevent as i think).