### PR TITLE
make websocket connection working with SSL

### DIFF
--- a/js/linuxDash.js
+++ b/js/linuxDash.js
@@ -65,7 +65,7 @@
      */
     var establishWebsocketConnection = function() {
 
-      var websocketUrl = 'ws://' + window.location.hostname + ':' + window.location.port;
+      var websocketUrl = (location.protocol === 'https:' ? 'wss://' : 'ws://') + window.location.hostname + ':' + window.location.port;
 
       if (websocket.connection === null) {
 


### PR DESCRIPTION
This fix checks if the dashboard is loaded via HTTPS and connects to the websocket server on the same host via wss (secure websocket).