### PR TITLE
Add npm start to package.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 vendor
 node_modules
+*.log

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "A simple, low overhead web dashboard for linux.",
   "main": "server/index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node server"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This follows node and npm common usage for starting node.js applications / services.

- add command `npm start`
- add *.log to `.gitignore` (npm-debug.log, etc)