### PR TITLE
Allow PORT environment variable to be used

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -6,7 +6,7 @@ var spawn   = require('child_process').spawn;
 var fs      = require('fs');
 var ws      = require('websocket').server;
 
-server.listen(80);
+server.listen(process.env.PORT || 80);
 console.log('Linux Dash Server Started!');
 
 app.use(express.static(path.resolve(__dirname + '/../')));


### PR DESCRIPTION
`PORT=3000 npm start` will use port 3000 for the HTTP server rather than 80.