### PR TITLE
Raid module

### DIFF
--- a/js/modules.js
+++ b/js/modules.js
@@ -271,7 +271,7 @@
     {
       name: 'pm2',
       template: '<table-data heading="P(rocess) M(anager) 2" module-name="pm2" info="pm2 read-out."></table-data>'
-    },    
+    },
     {
       name: 'memoryInfo',
       template: '<key-value-list heading="Memory Info" module-name="memory_info" info="/proc/meminfo read-out."></key-value-list>'
@@ -291,7 +291,11 @@
     {
       name: 'cronHistory',
       template: '<table-data heading="Cron Job History" module-name="cron_history" info="Crons which have run recently."></table-data>'
-    }
+    },
+    {
+      name: 'raidStats',
+      template: '<table-data heading="RAID Sats" module-name="raid_status" info="RAID Status from /proc/mdstats"></table-data>'
+    },
   ];
 
   simpleTableModules.forEach(function(module, key) {

--- a/python-server.py
+++ b/python-server.py
@@ -1,9 +1,17 @@
 #!/usr/bin/env python
 
+from __future__ import print_function
 import os
+import sys
 from BaseHTTPServer import BaseHTTPRequestHandler, HTTPServer, test as _test
 import subprocess
 from SocketServer import ThreadingMixIn
+import argparse
+
+
+parser = argparse.ArgumentParser(description='Simple Threaded HTTP server to run linux-dash.')
+parser.add_argument('--port', metavar='PORT', type=int, nargs='?', default=80,
+                    help='Port to run the server on.')
 
 modulesSubPath = '/server/modules/shell_files/'
 serverPath = os.path.dirname(os.path.realpath(__file__))
@@ -40,6 +48,7 @@ class MainHandler(BaseHTTPRequestHandler):
             self.send_error(404, 'File Not Found: %s' % self.path)
 
 if __name__ == '__main__':
-    server = ThreadedHTTPServer(('0.0.0.0', 80), MainHandler)
-    print 'Starting server, use <Ctrl-C> to stop'
+    args = parser.parse_args()
+    server = ThreadedHTTPServer(('0.0.0.0', args.port), MainHandler)
+    print('Starting server, use <Ctrl-C> to stop')
     server.serve_forever()

--- a/server/modules/shell_files/raid_status.sh
+++ b/server/modules/shell_files/raid_status.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/perl
+
+
+my($devinfo_re, $devstat_re, $action_re) = (
+    '(md\d+)\s+:\s+active\s+(\(read-only\)\s+|\(auto-read-only\)\s+|)(\w+)\s+(.*)',
+    '.*\[(\d+)\/(\d+)]\s+\[(\w+)]',
+    '.*(reshape|check|resync|recovery)\s*=\s*(\d+\.\d+%|\w+)(.*finish=(.*min))?',
+);
+# Interestingly, swap is presented as "active (auto-read-only)"
+# and mdadm has '--readonly' option to make the array 'active (read-only)'
+print "[";
+
+open(my $mdstat, "/proc/mdstat");
+my(@text) = <$mdstat>;
+# contents of <$mdstat> may be changed at next reading, so fetch the contents at a time
+close($mdstat);
+
+my($dev, $ro, $type, $members, $nmem, $nact, $status, $action, $proc, $minute, $idx);
+while (@text) {
+    my $line = shift @text;
+    if ($line =~ /$devinfo_re/) {
+        # first line should like "active raid1 sda1[0] sdc1[2] sdb1[1]"
+        $dev = $1;
+        $ro = $2 || '';
+        $type = $3;
+        $members = $4;
+
+        $line = shift @text;
+        if ($line =~ /$devstat_re/) {
+            # second line should like "123456 blocks super 1.2 [2/2] [UU]"
+            $nmem = $1;
+            $nact = $2;
+            $status = $3;
+        }
+        else {
+            # sencond line did not exist on /proc/mdstat
+            next;
+        }
+
+        $line = shift @text;
+        if ($line =~ /$action_re/) {
+            # third line should like " [==>..................]  check = 10.0% (12345/123456) finish=123min speed=12345/sec"
+            # this line will appear only when the array is in action
+            $action = $1;
+            my $percent = $2;
+            $minute = $4 || '';
+            if ($percent =~ /(\d+\.\d+)%/) {
+                $proc = $1;
+            }
+            else {
+                # 'resync=DELAYED' or 'resync=PENDING'
+                $action .= " ($percent)";
+                $proc = -1;
+            }
+        }
+        else {
+            # array is not in action
+            $action = 'idle';
+            $minute = '';
+            unshift(@text, $line);
+        }
+    }
+    else {
+        # skip until first line is found
+        next;
+    }
+
+    if ( $ARGV[0] and $ARGV[0] eq "config" ) {
+        print "$dev.label $dev\n";
+        print "$dev.info $type $ro$members\n";
+        # 100: means less than 100
+        # Because of an unfound bug, sometimes reported as 99.XX even when OS reports 100.
+        print "$dev.critical 98:\n";
+        print $dev, "_rebuild.label $dev reshape/recovery\n";
+        print $dev, "_rebuild.info $action $minute\n";
+        # Because of an unfound bug, sometimes reported as 99.XX even when OS reports 100.
+        print $dev, "_rebuild.critical 98:\n";
+        print $dev, "_check.label $dev check/resync \n";
+        print $dev, "_check.info $action $minute\n";
+    } else {
+        my $pct = 100 * $nact / $nmem;
+        my $rpct = 100;
+        my $cpct = 100;
+        if ($action =~ /reshape|recovery/) {
+            $rpct = $proc;
+            $cpct = 0;  # check/resync is not done
+        }
+        elsif ($action =~ /check|resync/) {
+            if ($proc < 0) {
+                # array is on DELAYED or PENDING, further info is unknown
+                $rpct = 0;
+                $cpct = 0;
+            }
+            else {
+                # reshape/recovery was done, $rpct => 100
+                $cpct = $proc;
+            }
+        }
+
+        if($idx > 0) {
+          print ", \n";
+        }
+        print "{ \"device\": \"$dev\", \"value\": $pct, \"rebuild\": $rpct, \"check\": $cpct }";
+
+    }
+    $idx = $idx + 1;
+
+}
+print "]";

--- a/templates/sections/system-status.html
+++ b/templates/sections/system-status.html
@@ -7,3 +7,4 @@
 <swap-usage></swap-usage>
 <disk-space></disk-space>
 <cpu-temp></cpu-temp>
+<raid-stats></raid-stats>


### PR DESCRIPTION
Hi, I have created a simple module to monitor the status of RAID modules, which basically outputs 
stuff from /proc/mdstat. 

<img width="498" alt="dash-raid-module" src="https://cloud.githubusercontent.com/assets/713346/17462332/c44cfccc-5ca9-11e6-9eea-33b5c8d9f0a7.png">

(based on a Michal Ludvig's work for Nagios: http://www.logix.cz/michal/devel/nagios)

I also included some fixes for the python server to make it more user-friendly :) (custom port, python2 binary instead of python since some distros use python3 by default)

Tell me what you are missing/should be changed :)


Cheers, Claus
