### PR TITLE
#447 - Make sure the module is a valid function in the bash file

### DIFF
--- a/app/server/linux_json_api.sh
+++ b/app/server/linux_json_api.sh
@@ -622,7 +622,6 @@ upload_transfer_rate() {
 }
 
 user_accounts() {
-
   result=$($AWK -F: '{ \
           if ($3<=499){userType="system";} \
           else {userType="user";} \
@@ -640,4 +639,11 @@ user_accounts() {
 
 fnCalled="$1"
 
-${fnCalled}
+# Check if the function call is indeed a function.
+if [ -n "$(type -t $fnCalled)" ] && [ "$(type -t $fnCalled)" = function ];
+then
+    ${fnCalled}
+else
+    echo '{"success":false,"status":"Invalid module"}'
+fi
+

--- a/app/server/linux_json_api.sh
+++ b/app/server/linux_json_api.sh
@@ -640,10 +640,9 @@ user_accounts() {
 fnCalled="$1"
 
 # Check if the function call is indeed a function.
-if [ -n "$(type -t $fnCalled)" ] && [ "$(type -t $fnCalled)" = function ];
-then
+if [ -n "$(type -t $fnCalled)" ] && [ "$(type -t $fnCalled)" = function ]; then
     ${fnCalled}
 else
-    echo '{"success":false,"status":"Invalid module"}'
+    echo '{\"success\":false,\"status\":\"Invalid module\"}'
 fi
 


### PR DESCRIPTION
Fixes #447 - Shell command injection prevention by checking if the "module" is a valid function within the bash script.

### Proof

![image](https://user-images.githubusercontent.com/939247/32666053-417fb36e-c604-11e7-8d6c-b4c85e7f3cf1.png)
