### PR TITLE
Add host customization support for the NodeJS version

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,9 @@ npm install --production
 ## start linux-dash (on port 80 by default; may require sudo)
 ## You may change this with the `LINUX_DASH_SERVER_PORT` environment variable (eg. `LINUX_DASH_SERVER_PORT=8080 node server`)
 ## or provide a --port flag to the command below
+## Additionally, the server will listen on every network interface (`0.0.0.0`).
+## You may change this with the `LINUX_DASH_SERVER_HOST` environment variable (eg. `LINUX_DASH_SERVER_HOST=127.0.0.1 node server`)
+## or provide a --host flag to the command below
 node index.js
 
 ```

--- a/app/server/index.js
+++ b/app/server/index.js
@@ -6,10 +6,11 @@ var spawn   = require('child_process').spawn
 var fs      = require('fs')
 var ws      = require('websocket').server
 var args    = require('yargs').argv
+var host    = args.host || process.env.LINUX_DASH_SERVER_HOST || '0.0.0.0'
 var port    = args.port || process.env.LINUX_DASH_SERVER_PORT || 80
 
-server.listen(port, function() {
-  console.log('Linux Dash Server Started on port ' + port + '!');
+server.listen(port, host, function() {
+  console.log('Linux Dash Server Started on ' + host + ':' + port + '!');
 })
 
 app.use(express.static(path.resolve(__dirname + '/../')))


### PR DESCRIPTION
Currently, when the process starts, it listens on the "everyting" interface (as defined in the NodeJS documentation)

> If host is omitted, the server will accept connections on the unspecified IPv6 address (::) when IPv6 is available, or the unspecified IPv4 address (0.0.0.0) otherwise.
>
> *[Source](https://nodejs.org/api/net.html#net_server_listen)*

This tool is awesome, but running it in production on *every* interface is not always wanted, so this PR introduces a way to define the host when running the app.