### PR TITLE
fix field name in function bandwidth

### DIFF
--- a/app/server/linux_json_api.sh
+++ b/app/server/linux_json_api.sh
@@ -39,8 +39,8 @@ bandwidth() {
 
   $CAT /proc/net/dev \
   | $AWK 'BEGIN {print "["} NR>2 {print "{ \"interface\": \"" $1 "\"," \
-            " \"tx\": " $2 "," \
-            " \"rx\": " $10 " }," } END {print "]"}' \
+            " \"rx\": " $2 "," \
+            " \"tx\": " $10 " }," } END {print "]"}' \
   | $SED 'N;$s/,\n/\n/;P;D' \
   | _parseAndPrint
 }


### PR DESCRIPTION
I think there is a bug in the function `bandwidth` in the `linux_json_api.sh` file. `$2` should be `rx`instead of `tx`, and $10 should be `tx` instead of `rx`

![image](https://user-images.githubusercontent.com/17776713/82358840-aa591680-9a39-11ea-84c6-49e3027d284b.png)
