### PR TITLE
Enable cross-site access for GET method.

### DIFF
--- a/app/server/index.py
+++ b/app/server/index.py
@@ -41,6 +41,8 @@ class MainHandler(BaseHTTPRequestHandler):
                 f.close()
             self.send_response(200)
             self.send_header('Content-type', contentType)
+            self.send_header('Access-Control-Allow-Origin', '*')
+            self.send_header('Access-Control-Allow-Methods', 'GET')
             self.end_headers()
             self.wfile.write(data)
 


### PR DESCRIPTION
Enable cross-site access for all hosts, by GET method in `index.py`.

Allow to get load data in browser.